### PR TITLE
fix: sync pyproject version and fix stale marketplace refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Prerequisites: [Python 3.10+](https://www.python.org/downloads/) (check "Add to 
 
 **macOS / Linux**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py | python3
+curl -fsSL https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py | python3
 ```
 
 **Windows (CMD / PowerShell)**
 ```bat
-python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py').read())"
+python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py').read())"
 ```
 
 Verify:
@@ -75,7 +75,7 @@ For terminal usage, see Command Reference below.
 
 This tool works best with AI agents. Install the Skill so the agent knows how to use these commands.
 
-👉 **Install the Skill**: [narrator-ai-cli-skill](https://github.com/GridLtd-ProductDev/narrator-ai-cli-skill)
+👉 **Install the Skill**: [narrator-ai-cli-skill](https://github.com/NarratorAI-Studio/narrator-ai-cli-skill)
 
 ### Tested Platforms
 
@@ -254,7 +254,7 @@ narrator-ai-cli task query <task_id> --json
 
 ## AI Agent Integration
 
-See [narrator-ai-cli-skill](https://github.com/GridLtd-ProductDev/narrator-ai-cli-skill) for the complete SKILL.md that teaches AI agents how to use this tool automatically.
+See [narrator-ai-cli-skill](https://github.com/NarratorAI-Studio/narrator-ai-cli-skill) for the complete SKILL.md that teaches AI agents how to use this tool automatically.
 
 ## Contact
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -32,12 +32,12 @@ Narrator AI CLI 是 [AI 解说大师](https://ai.jieshuo.cn/) 的命令行工具
 
 **macOS / Linux**
 ```bash
-curl -fsSL https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py | python3
+curl -fsSL https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py | python3
 ```
 
 **Windows（CMD / PowerShell 均可）**
 ```bat
-python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py').read())"
+python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py').read())"
 ```
 
 验证安装：
@@ -71,7 +71,7 @@ narrator-ai-cli config set app_key 你的API_Key
 
 本工具搭配 AI Agent 使用效果最佳。安装 Skill 后，AI 就能理解如何使用这些命令。
 
-👉 **安装 Skill**：[narrator-ai-cli-skill](https://github.com/GridLtd-ProductDev/narrator-ai-cli-skill)
+👉 **安装 Skill**：[narrator-ai-cli-skill](https://github.com/NarratorAI-Studio/narrator-ai-cli-skill)
 
 ### 已测试的 Agent 平台
 
@@ -250,7 +250,7 @@ narrator-ai-cli task query <task_id> --json
 
 ## AI Agent 集成
 
-详见 [narrator-ai-cli-skill](https://github.com/GridLtd-ProductDev/narrator-ai-cli-skill)，包含完整的 SKILL.md 文件，让 AI Agent 自动理解如何使用本工具。
+详见 [narrator-ai-cli-skill](https://github.com/NarratorAI-Studio/narrator-ai-cli-skill)，包含完整的 SKILL.md 文件，让 AI Agent 自动理解如何使用本工具。
 
 ## 联系我们
 

--- a/install.py
+++ b/install.py
@@ -5,10 +5,10 @@ Works on Windows (CMD / PowerShell), macOS, and Linux — no shell-specific tool
 
 Usage:
   macOS / Linux:
-    curl -fsSL https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py | python3
+    curl -fsSL https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py | python3
 
   Windows (CMD or PowerShell):
-    python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/GridLtd-ProductDev/narrator-ai-cli/main/install.py').read())"
+    python -c "import urllib.request; exec(urllib.request.urlopen('https://raw.githubusercontent.com/NarratorAI-Studio/narrator-ai-cli/main/install.py').read())"
 
 Prerequisites: Python 3.10+, Git
 """
@@ -23,7 +23,7 @@ from pathlib import Path
 IS_WINDOWS = sys.platform == "win32"
 
 # ── Config ────────────────────────────────────────────────────────────────────
-REPO        = "https://github.com/GridLtd-ProductDev/narrator-ai-cli.git"
+REPO        = "https://github.com/NarratorAI-Studio/narrator-ai-cli.git"
 HOME        = Path.home()
 INSTALL_DIR = Path(os.environ.get("NARRATOR_INSTALL_DIR", HOME / ".narrator-ai-cli"))
 VENV_DIR    = INSTALL_DIR / ".venv"

--- a/marketplace.json
+++ b/marketplace.json
@@ -3,9 +3,9 @@
   "owner": {
     "name": "GridLtd-ProductDev",
     "email": "merlinyang@gridltd.com",
-    "url": "https://github.com/jieshuo-ai"
+    "url": "https://github.com/GridLtd-ProductDev"
   },
-  "description": "AI video narration production toolkit — create film commentary videos with AI-generated scripts, dubbing, BGM, and visual templates. Supports 93 pre-built movies, 146 BGM tracks, 63 dubbing voices in 11 languages, and 90+ narration style templates.",
+  "description": "AI video narration production toolkit — create film commentary videos with AI-generated scripts, dubbing, BGM, and visual templates. Supports pre-built movies, BGM tracks, dubbing voices in 11 languages, and narration style templates.",
   "plugins": [
     {
       "name": "narrator-ai-cli-skill",
@@ -13,7 +13,7 @@
       "version": "1.0.0",
       "source": {
         "source": "github",
-        "repo": "jieshuo-ai/narrator-ai-cli-skill"
+        "repo": "GridLtd-ProductDev/narrator-ai-cli-skill"
       },
       "category": "media-production",
       "tags": [

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,9 +1,9 @@
 {
   "name": "narrator-ai",
   "owner": {
-    "name": "GridLtd-ProductDev",
+    "name": "NarratorAI-Studio",
     "email": "merlinyang@gridltd.com",
-    "url": "https://github.com/GridLtd-ProductDev"
+    "url": "https://github.com/NarratorAI-Studio"
   },
   "description": "AI video narration production toolkit — create film commentary videos with AI-generated scripts, dubbing, BGM, and visual templates. Supports pre-built movies, BGM tracks, dubbing voices in 11 languages, and narration style templates.",
   "plugins": [
@@ -13,7 +13,7 @@
       "version": "1.0.0",
       "source": {
         "source": "github",
-        "repo": "GridLtd-ProductDev/narrator-ai-cli-skill"
+        "repo": "NarratorAI-Studio/narrator-ai-cli-skill"
       },
       "category": "media-production",
       "tags": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "narrator-ai-cli"
-version = "0.1.0"
+version = "1.0.0"
 description = "CLI client for Narrator AI API - designed for AI Agents and developers"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/narrator_ai/__init__.py
+++ b/src/narrator_ai/__init__.py
@@ -1,5 +1,5 @@
 """Narrator AI CLI - Command-line client for Narrator AI API."""
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 DOCS_URL = "https://ceex7z9m67.feishu.cn/wiki/WLPnwBysairenFkZDbicZOfKnbc"


### PR DESCRIPTION
## Summary
- Align `pyproject.toml` version (`0.1.0` → `1.0.0`) with Git tag `v1.0.0`
- Replace residual `jieshuo-ai` references in `marketplace.json` (`owner.url`, `source.repo`)
- Remove hardcoded resource counts from `marketplace.json` description

## Test plan
- [ ] Verify `pip install .` reads correct version 1.0.0
- [ ] Verify marketplace.json URLs point to correct organization