### PR TITLE
feat(ci): add Tier 1 testing pipeline — lint, typecheck, test, security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install -e "." pip-audit bandit
+      - run: pip install "." pip-audit bandit
         env:
           PIP_INDEX_URL: https://pypi.org/simple
       - run: pip-audit --strict --skip-editable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,12 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install pip-audit bandit
-      - name: Audit dependencies
-        run: |
-          pip install "." --quiet
-          pip-audit --desc --skip-editable
+      - name: Install project
+        run: pip install -e ".[dev]"
         env:
           PIP_INDEX_URL: https://pypi.org/simple
+      - name: Audit dependencies
+        # Known CVEs tracked in issue #14 — non-blocking until deps are upgraded
+        continue-on-error: true
+        run: pip-audit --desc --skip-editable
       - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,10 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install pip-audit bandit
-      - name: Generate requirements and audit
+      - name: Audit dependencies
         run: |
           pip install "." --quiet
-          pip freeze --exclude-editable > /tmp/requirements.txt
+          pip freeze | grep -iv "^narrator-ai-cli==" > /tmp/requirements.txt
           pip-audit -r /tmp/requirements.txt --strict
         env:
           PIP_INDEX_URL: https://pypi.org/simple

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,5 @@ jobs:
       - run: pip install -e "." pip-audit bandit
         env:
           PIP_INDEX_URL: https://pypi.org/simple
-      - run: pip-audit --strict
+      - run: pip-audit --strict --skip-editable
       - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,7 @@ jobs:
       - name: Audit dependencies
         run: |
           pip install "." --quiet
-          pip freeze | grep -iv "^narrator-ai-cli==" > /tmp/requirements.txt
-          pip-audit -r /tmp/requirements.txt --strict
+          pip-audit --desc --skip-editable
         env:
           PIP_INDEX_URL: https://pypi.org/simple
       - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,5 @@ jobs:
         env:
           PIP_INDEX_URL: https://pypi.org/simple
       - name: Audit dependencies
-        # Known CVEs tracked in issue #14 — non-blocking until deps are upgraded
-        continue-on-error: true
         run: pip-audit --desc --skip-editable
       - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop, "release/*"]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install ruff
+      - run: ruff check .
+      - run: ruff format --check .
+
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]" mypy types-PyYAML
+        env:
+          PIP_INDEX_URL: https://pypi.org/simple
+      - run: mypy src/narrator_ai --ignore-missing-imports
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: pip install -e ".[dev]" pytest-cov
+        env:
+          PIP_INDEX_URL: https://pypi.org/simple
+      - run: pytest -v --tb=short --cov=narrator_ai --cov-report=xml
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -e "." pip-audit bandit
+        env:
+          PIP_INDEX_URL: https://pypi.org/simple
+      - run: pip-audit --strict
+      - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,12 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "." pip-audit bandit
+      - run: pip install pip-audit bandit
+      - name: Generate requirements and audit
+        run: |
+          pip install "." --quiet
+          pip freeze --exclude-editable > /tmp/requirements.txt
+          pip-audit -r /tmp/requirements.txt --strict
         env:
           PIP_INDEX_URL: https://pypi.org/simple
-      - run: pip-audit --strict --skip-editable
       - run: bandit -r src/narrator_ai -c pyproject.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -24,7 +24,7 @@ jobs:
 
   typecheck:
     name: Type Check
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -37,7 +37,7 @@ jobs:
 
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
@@ -53,7 +53,7 @@ jobs:
 
   security:
     name: Security Scan
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,12 @@ dev = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=1.0.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
+    "types-PyYAML>=6.0",
+    "bandit>=1.7",
+    "pip-audit>=2.7",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,18 @@ dependencies = [
 [project.scripts]
 narrator-ai-cli = "narrator_ai.cli:app"
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=1.0.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.4",
+    "mypy>=1.10",
+    "types-PyYAML>=6.0",
+    "bandit>=1.7",
+    "pip-audit>=2.7",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=8.0.0",
@@ -31,3 +43,25 @@ packages = ["src/narrator_ai"]
 [[tool.uv.index]]
 url = "https://mirrors.aliyun.com/pypi/simple"
 default = true
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+extend-exclude = ["scripts", "install.py"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "N", "UP", "B", "SIM", "S"]
+ignore = ["S101", "S108", "S603", "S607", "B904", "E501", "UP036"]
+
+[tool.mypy]
+python_version = "3.10"
+warn_return_any = false
+warn_unused_configs = true
+disallow_untyped_defs = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-v --tb=short"
+
+[tool.bandit]
+exclude_dirs = ["tests"]

--- a/src/narrator_ai/cli.py
+++ b/src/narrator_ai/cli.py
@@ -51,7 +51,11 @@ def version_callback(value: bool):
 @app.callback()
 def main(
     version: bool = typer.Option(
-        False, "--version", "-v", callback=version_callback, is_eager=True,
+        False,
+        "--version",
+        "-v",
+        callback=version_callback,
+        is_eager=True,
         help="Show version and exit.",
     ),
 ):

--- a/src/narrator_ai/client.py
+++ b/src/narrator_ai/client.py
@@ -4,7 +4,7 @@ Wraps httpx with automatic auth headers, error handling, and SSE support.
 """
 
 import json as _json
-from typing import Any, Optional
+from typing import Any
 
 import httpx
 from httpx_sse import connect_sse
@@ -23,14 +23,14 @@ class NarratorAPIError(Exception):
 class NarratorClient:
     def __init__(
         self,
-        server: Optional[str] = None,
-        app_key: Optional[str] = None,
-        timeout: Optional[int] = None,
+        server: str | None = None,
+        app_key: str | None = None,
+        timeout: int | None = None,
     ):
         self.server = server if server is not None else get_server()
         self.app_key = app_key if app_key is not None else get_app_key()
         self.timeout = timeout if timeout is not None else get_timeout()
-        self._client: Optional[httpx.Client] = None
+        self._client: httpx.Client | None = None
 
     def _get_client(self, **kwargs) -> httpx.Client:
         """Get or create a reusable httpx.Client."""
@@ -58,7 +58,7 @@ class NarratorClient:
             raise NarratorAPIError(code, data.get("message", "Unknown error"))
         return data.get("data")
 
-    def get(self, path: str, params: Optional[dict] = None) -> Any:
+    def get(self, path: str, params: dict | None = None) -> Any:
         client = self._get_client()
         resp = client.get(self._url(path), params=params)
         return self._handle_response(resp)
@@ -66,47 +66,49 @@ class NarratorClient:
     def post(
         self,
         path: str,
-        json: Optional[dict] = None,
-        params: Optional[dict] = None,
+        json: dict | None = None,
+        params: dict | None = None,
     ) -> Any:
         client = self._get_client()
         resp = client.post(self._url(path), json=json, params=params)
         return self._handle_response(resp)
 
-    def post_sse(self, path: str, json: Optional[dict] = None):
+    def post_sse(self, path: str, json: dict | None = None):
         """POST with SSE streaming. Yields (event_type, data_dict) tuples."""
         headers = {**self._headers(), "Accept": "text/event-stream"}
-        with httpx.Client(timeout=httpx.Timeout(self.timeout, read=300.0)) as c:
-            with connect_sse(
-                c, "POST", self._url(path), headers=headers, json=json
-            ) as sse:
-                for event in sse.iter_sse():
-                    event_type = event.event or "message"
-                    try:
-                        event_data = _json.loads(event.data)
-                    except (ValueError, TypeError):
-                        event_data = {"raw": event.data}
-                    yield event_type, event_data
+        with (
+            httpx.Client(timeout=httpx.Timeout(self.timeout, read=300.0)) as c,
+            connect_sse(c, "POST", self._url(path), headers=headers, json=json) as sse,
+        ):
+            for event in sse.iter_sse():
+                event_type = event.event or "message"
+                try:
+                    event_data = _json.loads(event.data)
+                except (ValueError, TypeError):
+                    event_data = {"raw": event.data}
+                yield event_type, event_data
 
-    def delete(self, path: str, params: Optional[dict] = None) -> Any:
+    def delete(self, path: str, params: dict | None = None) -> Any:
         client = self._get_client()
         resp = client.delete(self._url(path), params=params)
         return self._handle_response(resp)
 
     def upload_file(self, upload_url: str, file_path: str, content_type: str = "application/octet-stream"):
         """Upload file to presigned URL."""
-        with open(file_path, "rb") as f:
-            with httpx.Client(timeout=httpx.Timeout(connect=self.timeout, read=600.0, write=None, pool=self.timeout)) as c:
-                resp = c.put(
-                    upload_url,
-                    content=f,
-                    headers={"Content-Type": content_type},
-                )
-                try:
-                    resp.raise_for_status()
-                except httpx.HTTPStatusError as e:
-                    raise NarratorAPIError(resp.status_code, f"Upload failed: HTTP {resp.status_code}") from e
-                return resp
+        with (
+            open(file_path, "rb") as f,
+            httpx.Client(timeout=httpx.Timeout(connect=self.timeout, read=600.0, write=None, pool=self.timeout)) as c,
+        ):
+            resp = c.put(
+                upload_url,
+                content=f,
+                headers={"Content-Type": content_type},
+            )
+            try:
+                resp.raise_for_status()
+            except httpx.HTTPStatusError as e:
+                raise NarratorAPIError(resp.status_code, f"Upload failed: HTTP {resp.status_code}") from e
+            return resp
 
     def close(self):
         if self._client and not self._client.is_closed:

--- a/src/narrator_ai/commands/bgm.py
+++ b/src/narrator_ai/commands/bgm.py
@@ -1,11 +1,9 @@
 """Pre-built BGM (background music) resources for task creation."""
 
-from typing import Optional
-
 import typer
 
-from narrator_ai.output import console, print_error, print_json, print_table
 from narrator_ai import DOCS_URL
+from narrator_ai.output import console, print_error, print_json, print_table
 
 app = typer.Typer(
     help=(
@@ -168,7 +166,7 @@ BGM_LIST = [
 
 @app.command("list")
 def list_bgm(
-    search: Optional[str] = typer.Option(None, "--search", "-s", help="Search by BGM name"),
+    search: str | None = typer.Option(None, "--search", "-s", help="Search by BGM name"),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List pre-built BGM tracks. Use the ID as 'bgm' parameter in task creation.

--- a/src/narrator_ai/commands/dubbing.py
+++ b/src/narrator_ai/commands/dubbing.py
@@ -155,7 +155,7 @@ def list_languages(
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List available dubbing languages (dubbing_type values) with counts."""
-    lang_counts = {}
+    lang_counts: dict[str, int] = {}
     for d in DUBBING_LIST:
         lang_counts[d["type"]] = lang_counts.get(d["type"], 0) + 1
     items = [{"language": lang, "count": cnt} for lang, cnt in sorted(lang_counts.items())]
@@ -175,7 +175,7 @@ def list_tags(
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List available voice tags (genre recommendations) with counts."""
-    tag_counts = {}
+    tag_counts: dict[str, int] = {}
     for d in DUBBING_LIST:
         tag_counts[d["tag"]] = tag_counts.get(d["tag"], 0) + 1
     items = [{"tag": t, "count": c} for t, c in sorted(tag_counts.items())]

--- a/src/narrator_ai/commands/dubbing.py
+++ b/src/narrator_ai/commands/dubbing.py
@@ -1,11 +1,9 @@
 """Pre-built dubbing (voice) resources for task creation."""
 
-from typing import Optional
-
 import typer
 
-from narrator_ai.output import console, print_error, print_json, print_table
 from narrator_ai import DOCS_URL
+from narrator_ai.output import console, print_error, print_json, print_table
 
 app = typer.Typer(
     help=(
@@ -42,13 +40,23 @@ DUBBING_LIST = [
     {"name": "严肃青年解说-适合动作、冒险类", "id": "mercury_yunxi_24k@serious", "type": "普通话", "tag": "动作冒险"},
     {"name": "气泡音男声-适合动作、冒险类", "id": "momoyuan_meet_24k", "type": "普通话", "tag": "动作冒险"},
     {"name": "慵懒调侃男声-适合动作、冒险类", "id": "jupiter_BV107DialogMale", "type": "普通话", "tag": "动作冒险"},
-    {"name": "神秘女声-适合动作、冒险、恐怖、惊悚类", "id": "galaxy_fastv7_moyingxi@angry", "type": "普通话", "tag": "动作冒险"},
+    {
+        "name": "神秘女声-适合动作、冒险、恐怖、惊悚类",
+        "id": "galaxy_fastv7_moyingxi@angry",
+        "type": "普通话",
+        "tag": "动作冒险",
+    },
     {"name": "东北老妹儿-适合喜剧", "id": "mercury_ln-xiaobei_24k", "type": "普通话", "tag": "喜剧"},
     {"name": "幽默闲聊女声-适合喜剧", "id": "galaxy_fastv8_moxueqin", "type": "普通话", "tag": "喜剧"},
     {"name": "犀利青年音-适合喜剧", "id": "galaxy_fastv8_mowasi", "type": "普通话", "tag": "喜剧"},
     {"name": "恐惧感大叔音-适合恐怖、惊悚类", "id": "mercury_yunye_24k@fearful", "type": "普通话", "tag": "恐怖惊悚"},
     {"name": "恐惧低沉大叔音-适合恐怖、惊悚类", "id": "mercury_yunze_24k@fearful", "type": "普通话", "tag": "恐怖惊悚"},
-    {"name": "不安男声-适合恐怖、惊悚类、科幻", "id": "mercury_yunxi_48k@embarrassed", "type": "普通话", "tag": "恐怖惊悚"},
+    {
+        "name": "不安男声-适合恐怖、惊悚类、科幻",
+        "id": "mercury_yunxi_48k@embarrassed",
+        "type": "普通话",
+        "tag": "恐怖惊悚",
+    },
     {"name": "松弛大叔音-适合爱情、剧情类", "id": "mercury_yunyang_24k@newscast", "type": "普通话", "tag": "爱情剧情"},
     {"name": "元气少女音-适合爱情、剧情类", "id": "mercury_xiaochen_48k", "type": "普通话", "tag": "爱情剧情"},
     {"name": "磁性御姐音-适合爱情、剧情类", "id": "yangjingv_meet_24k", "type": "普通话", "tag": "爱情剧情"},
@@ -56,7 +64,12 @@ DUBBING_LIST = [
     {"name": "快嘴直爽青年-适合科幻类", "id": "moxidu_meet_24k@kehuan", "type": "普通话", "tag": "科幻"},
     {"name": "磁性悬疑男声-适合科幻类", "id": "manchaozn_meet_24k@boya", "type": "普通话", "tag": "科幻"},
     {"name": "冷静青年解说-适合历史、战争类", "id": "mercury_yunxi_48k@calm", "type": "普通话", "tag": "历史战争"},
-    {"name": "沉稳大叔音-适合历史、战争类", "id": "mercury_yunze_24k@documentary-narration", "type": "普通话", "tag": "历史战争"},
+    {
+        "name": "沉稳大叔音-适合历史、战争类",
+        "id": "mercury_yunze_24k@documentary-narration",
+        "type": "普通话",
+        "tag": "历史战争",
+    },
     {"name": "纪实磁性男声-适合历史、战争类", "id": "manchaozn_meet_24k@jilupian", "type": "普通话", "tag": "历史战争"},
     {"name": "沉稳御姐音-适合历史、战争类", "id": "liyuansong_meet_24k@tale", "type": "普通话", "tag": "历史战争"},
     # 英语
@@ -98,9 +111,11 @@ DUBBING_LIST = [
 
 @app.command("list")
 def list_dubbing(
-    lang: Optional[str] = typer.Option(None, "--lang", "-l", help="Filter by language/dubbing_type (e.g. 普通话, 英语, 日语)"),
-    tag: Optional[str] = typer.Option(None, "--tag", "-t", help="Filter by tag (e.g. 喜剧, 恐怖惊悚, 角色, 通用男声)"),
-    search: Optional[str] = typer.Option(None, "--search", "-s", help="Search by voice name"),
+    lang: str | None = typer.Option(
+        None, "--lang", "-l", help="Filter by language/dubbing_type (e.g. 普通话, 英语, 日语)"
+    ),
+    tag: str | None = typer.Option(None, "--tag", "-t", help="Filter by tag (e.g. 喜剧, 恐怖惊悚, 角色, 通用男声)"),
+    search: str | None = typer.Option(None, "--search", "-s", help="Search by voice name"),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List pre-built dubbing voices.
@@ -143,13 +158,16 @@ def list_languages(
     lang_counts = {}
     for d in DUBBING_LIST:
         lang_counts[d["type"]] = lang_counts.get(d["type"], 0) + 1
-    items = [{"language": l, "count": c} for l, c in sorted(lang_counts.items())]
+    items = [{"language": lang, "count": cnt} for lang, cnt in sorted(lang_counts.items())]
 
     if json_mode:
         print_json(items)
     else:
-        print_table(items, [("language", "Language (dubbing_type)"), ("count", "Count")],
-                    title=f"Dubbing Languages ({len(DUBBING_LIST)} voices)")
+        print_table(
+            items,
+            [("language", "Language (dubbing_type)"), ("count", "Count")],
+            title=f"Dubbing Languages ({len(DUBBING_LIST)} voices)",
+        )
 
 
 @app.command("tags")
@@ -165,5 +183,4 @@ def list_tags(
     if json_mode:
         print_json(items)
     else:
-        print_table(items, [("tag", "Tag"), ("count", "Count")],
-                    title=f"Voice Tags ({len(DUBBING_LIST)} voices)")
+        print_table(items, [("tag", "Tag"), ("count", "Count")], title=f"Voice Tags ({len(DUBBING_LIST)} voices)")

--- a/src/narrator_ai/commands/file.py
+++ b/src/narrator_ai/commands/file.py
@@ -268,9 +268,10 @@ def delete_file(
         raise typer.Exit(1)
 
 
-def _format_size(size: int) -> str:
+def _format_size(size: int | float) -> str:
+    s = float(size)
     for unit in ("B", "KB", "MB", "GB"):
-        if size < 1024:
-            return f"{size:.1f} {unit}"
-        size /= 1024
-    return f"{size:.1f} TB"
+        if s < 1024:
+            return f"{s:.1f} {unit}"
+        s /= 1024
+    return f"{s:.1f} TB"

--- a/src/narrator_ai/commands/file.py
+++ b/src/narrator_ai/commands/file.py
@@ -2,11 +2,10 @@
 
 import mimetypes
 from pathlib import Path
-from typing import Optional
 
 import typer
 
-from narrator_ai.client import NarratorClient, NarratorAPIError
+from narrator_ai.client import NarratorAPIError, NarratorClient
 from narrator_ai.output import (
     print_dict,
     print_error,
@@ -61,11 +60,14 @@ def upload(
     try:
         # Step 1: Get presigned upload URL
         print_info(f"Requesting upload URL for {file_name} ({file_size:,} bytes)...")
-        presigned = client.post("/v2/files/upload/presigned-url", json={
-            "file_name": file_name,
-            "file_size": file_size,
-            "content_type": content_type,
-        })
+        presigned = client.post(
+            "/v2/files/upload/presigned-url",
+            json={
+                "file_name": file_name,
+                "file_size": file_size,
+                "content_type": content_type,
+            },
+        )
 
         # Step 2: Upload to OSS
         upload_url = presigned["upload_url"]
@@ -74,12 +76,15 @@ def upload(
 
         # Step 3: Confirm callback
         print_info("Confirming upload...")
-        result = client.post("/v2/files/upload/callback", json={
-            "file_id": presigned["file_id"],
-            "object_key": presigned["object_key"],
-            "upload_status": "success",
-            "file_size": file_size,
-        })
+        client.post(
+            "/v2/files/upload/callback",
+            json={
+                "file_id": presigned["file_id"],
+                "object_key": presigned["object_key"],
+                "upload_status": "success",
+                "file_size": file_size,
+            },
+        )
 
         output = {
             "file_id": presigned["file_id"],
@@ -96,9 +101,11 @@ def upload(
 
 @app.command()
 def transfer(
-    link: Optional[str] = typer.Option(None, help="File link (HTTP URL, Baidu Netdisk share link, or PikPak link)"),
-    upload_id: Optional[str] = typer.Option(None, help="Upload ID associated with the file being transferred"),
-    type: Optional[str] = typer.Option(None, help="Link type: url=HTTP, baidu=Baidu Netdisk, pikpak=PikPak (auto-detected if omitted)"),
+    link: str | None = typer.Option(None, help="File link (HTTP URL, Baidu Netdisk share link, or PikPak link)"),
+    upload_id: str | None = typer.Option(None, help="Upload ID associated with the file being transferred"),
+    type: str | None = typer.Option(
+        None, help="Link type: url=HTTP, baidu=Baidu Netdisk, pikpak=PikPak (auto-detected if omitted)"
+    ),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """Transfer a remote file to cloud storage by link (HTTP, Baidu Netdisk, or PikPak).
@@ -144,18 +151,24 @@ def download(
 ):
     """Get a presigned download URL for a file. URL expires after a limited time."""
     try:
-        data = _client().post("/v2/files/download/presigned-url", json={
-            "file_id": file_id,
-        })
+        data = _client().post(
+            "/v2/files/download/presigned-url",
+            json={
+                "file_id": file_id,
+            },
+        )
         if json_mode:
             print_json(data)
         else:
-            print_dict({
-                "file_id": data.get("file_id"),
-                "file_name": data.get("file_name"),
-                "download_url": data.get("download_url"),
-                "expires_in": f"{data.get('expires_in', 0)} seconds",
-            }, title="Download URL")
+            print_dict(
+                {
+                    "file_id": data.get("file_id"),
+                    "file_name": data.get("file_name"),
+                    "download_url": data.get("download_url"),
+                    "expires_in": f"{data.get('expires_in', 0)} seconds",
+                },
+                title="Download URL",
+            )
     except NarratorAPIError as e:
         print_error(e.message, e.code)
         raise typer.Exit(1)
@@ -165,7 +178,7 @@ def download(
 def list_files(
     page: int = typer.Option(1, help="Page number"),
     page_size: int = typer.Option(10, help="Items per page"),
-    search: Optional[str] = typer.Option(None, help="Filter by filename (substring match)"),
+    search: str | None = typer.Option(None, help="Filter by filename (substring match)"),
     order_by: str = typer.Option("completed_time", help="Sort field: completed_time, created_at, file_size"),
     order: str = typer.Option("desc", help="Sort order: asc or desc"),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),

--- a/src/narrator_ai/commands/materials.py
+++ b/src/narrator_ai/commands/materials.py
@@ -2,9 +2,9 @@
 
 import typer
 
-from narrator_ai.client import NarratorClient, NarratorAPIError
-from narrator_ai.output import console, print_error, print_json, print_table
 from narrator_ai import DOCS_URL
+from narrator_ai.client import NarratorAPIError, NarratorClient
+from narrator_ai.output import console, print_error, print_json, print_table
 
 app = typer.Typer(
     help=(

--- a/src/narrator_ai/commands/task.py
+++ b/src/narrator_ai/commands/task.py
@@ -278,7 +278,7 @@ def query(
     try:
         data = _client().get(f"/v2/task/commentary/query/{task_id}")
         if not json_mode and isinstance(data, dict):
-            status_code = data.get("status")
+            status_code: int = data.get("status", -1)
             data["status_name"] = TASK_STATUS_MAP.get(status_code, str(status_code))
         print_dict(data, title=f"Task {task_id}", json_mode=json_mode)
     except NarratorAPIError as e:
@@ -304,7 +304,7 @@ def list_tasks(
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON (recommended for agents)"),
 ):
     """List tasks with pagination and optional filters."""
-    params = {"page": page, "limit": limit}
+    params: dict[str, int | str] = {"page": page, "limit": limit}
     if status is not None:
         params["status"] = status
     if task_type is not None:
@@ -319,7 +319,7 @@ def list_tasks(
         else:
             items = data.get("items", [])
             for item in items:
-                s = item.get("status")
+                s: int = item.get("status", -1)
                 item["status_name"] = TASK_STATUS_MAP.get(s, str(s))
             columns = [
                 ("task_id", "Task ID"),

--- a/src/narrator_ai/commands/task.py
+++ b/src/narrator_ai/commands/task.py
@@ -11,27 +11,26 @@ Supports two workflow paths:
 
 import json as _json
 from pathlib import Path
-from typing import Optional
 
 import typer
 
-from narrator_ai.client import NarratorClient, NarratorAPIError
-from narrator_ai.models.responses import (
-    TASK_STATUS_INIT,
-    TASK_STATUS_IN_PROGRESS,
-    TASK_STATUS_SUCCESS,
-    TASK_STATUS_FAILED,
-    TASK_STATUS_CANCELLED,
-)
 from narrator_ai import DOCS_URL
+from narrator_ai.client import NarratorAPIError, NarratorClient
+from narrator_ai.models.responses import (
+    TASK_STATUS_CANCELLED,
+    TASK_STATUS_FAILED,
+    TASK_STATUS_IN_PROGRESS,
+    TASK_STATUS_INIT,
+    TASK_STATUS_SUCCESS,
+)
 from narrator_ai.output import (
     console,
     print_dict,
     print_error,
+    print_info,
     print_json,
     print_sse_event,
     print_table,
-    print_info,
 )
 
 app = typer.Typer(
@@ -203,7 +202,9 @@ def create(
         help="Task type: popular-learning, generate-writing, fast-writing, clip-data, fast-clip-data, video-composing, magic-video, voice-clone, tts",
     ),
     data: str = typer.Option(
-        ..., "-d", "--data",
+        ...,
+        "-d",
+        "--data",
         help="Request body as JSON string or @file.json reference",
     ),
     stream: bool = typer.Option(False, "--stream", "-s", help="Use SSE streaming for real-time progress"),
@@ -289,14 +290,17 @@ def query(
 def list_tasks(
     page: int = typer.Option(1, help="Page number (starting from 1)"),
     limit: int = typer.Option(10, help="Items per page, max 100"),
-    status: Optional[int] = typer.Option(None, help="Filter by status: 0=init, 1=in_progress, 2=success, 3=failed, 4=cancelled"),
-    task_type: Optional[int] = typer.Option(
-        None, "--type",
-        help="Filter by type: 1=popular_learning, 2=generate_writing, 3=video_composing, "
-             "4=voice_clone, 5=tts, 6=clip_data, 7=magic_video, 8=subsync, "
-             "9=fast_writing, 10=fast_clip_data",
+    status: int | None = typer.Option(
+        None, help="Filter by status: 0=init, 1=in_progress, 2=success, 3=failed, 4=cancelled"
     ),
-    category: Optional[str] = typer.Option(None, help="Filter by category: translate or commentary"),
+    task_type: int | None = typer.Option(
+        None,
+        "--type",
+        help="Filter by type: 1=popular_learning, 2=generate_writing, 3=video_composing, "
+        "4=voice_clone, 5=tts, 6=clip_data, 7=magic_video, 8=subsync, "
+        "9=fast_writing, 10=fast_clip_data",
+    ),
+    category: str | None = typer.Option(None, help="Filter by category: translate or commentary"),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON (recommended for agents)"),
 ):
     """List tasks with pagination and optional filters."""
@@ -325,7 +329,8 @@ def list_tasks(
                 ("created_at", "Created"),
             ]
             print_table(
-                items, columns,
+                items,
+                columns,
                 title=f"Tasks (page {data.get('page')}/{max(1, -(-data.get('total', 0) // limit))}, total: {data.get('total', 0)})",
             )
     except NarratorAPIError as e:
@@ -389,10 +394,13 @@ def get_writing(
 ):
     """Retrieve generated narration script content for review or editing."""
     try:
-        data = _client().get("/v2/task/commentary/get_generate_writed", params={
-            "task_id": task_id,
-            "file_id": file_id,
-        })
+        data = _client().get(
+            "/v2/task/commentary/get_generate_writed",
+            params={
+                "task_id": task_id,
+                "file_id": file_id,
+            },
+        )
         print_dict(data, title="Generated Writing", json_mode=json_mode)
     except NarratorAPIError as e:
         print_error(e.message, e.code)
@@ -572,7 +580,7 @@ NARRATION_TEMPLATES = [
 
 @app.command("narration-styles")
 def list_narration_styles(
-    genre: Optional[str] = typer.Option(None, "--genre", "-g", help="Filter by genre (e.g. 情感人生, 烧脑悬疑, 爆笑喜剧)"),
+    genre: str | None = typer.Option(None, "--genre", "-g", help="Filter by genre (e.g. 情感人生, 烧脑悬疑, 爆笑喜剧)"),
     json_mode: bool = typer.Option(False, "--json", help="Output as JSON"),
 ):
     """List pre-built narration style templates (learning_model_id).

--- a/src/narrator_ai/commands/user.py
+++ b/src/narrator_ai/commands/user.py
@@ -2,7 +2,7 @@
 
 import typer
 
-from narrator_ai.client import NarratorClient, NarratorAPIError
+from narrator_ai.client import NarratorAPIError, NarratorClient
 from narrator_ai.output import print_dict, print_error, print_json, print_table
 
 app = typer.Typer(help="User account management: balance, authentication, and API key operations.")
@@ -41,11 +41,15 @@ def login(
     """
     try:
         from narrator_ai.config import get_server
+
         client = NarratorClient(server=get_server(), app_key="")
-        data = client.post("/v1/users/sign_in", json={
-            "username": username,
-            "password": password,
-        })
+        data = client.post(
+            "/v1/users/sign_in",
+            json={
+                "username": username,
+                "password": password,
+            },
+        )
         print_dict(data, title="Login Success", json_mode=json)
     except NarratorAPIError as e:
         print_error(e.message, e.code)
@@ -63,10 +67,13 @@ def keys(
     Returns: total, page, page_size, items[{id, app_key, credit_quota, credit_quota_balance, status, remark}].
     """
     try:
-        data = _client().get("/v1/users/app_key/sub/list", params={
-            "page": page,
-            "page_size": page_size,
-        })
+        data = _client().get(
+            "/v1/users/app_key/sub/list",
+            params={
+                "page": page,
+                "page_size": page_size,
+            },
+        )
         if json:
             print_json(data)
         else:
@@ -94,10 +101,13 @@ def create_key(
 ):
     """Create a new sub API key with optional quota and remark."""
     try:
-        data = _client().post("/v1/users/app_key/create", json={
-            "remark": remark,
-            "quota": quota,
-        })
+        data = _client().post(
+            "/v1/users/app_key/create",
+            json={
+                "remark": remark,
+                "quota": quota,
+            },
+        )
         print_dict(data, title="Sub Key Created", json_mode=json)
     except NarratorAPIError as e:
         print_error(e.message, e.code)

--- a/src/narrator_ai/config.py
+++ b/src/narrator_ai/config.py
@@ -25,7 +25,7 @@ def ensure_config_dir():
 def load_config() -> dict:
     if not CONFIG_FILE.exists():
         return dict(DEFAULT_CONFIG)
-    with open(CONFIG_FILE, "r") as f:
+    with open(CONFIG_FILE) as f:
         data = yaml.safe_load(f) or {}
     return {**DEFAULT_CONFIG, **data}
 
@@ -41,9 +41,7 @@ def get_server() -> str:
     cfg = load_config()
     server = os.environ.get("NARRATOR_SERVER", cfg.get("server", ""))
     if not server:
-        raise SystemExit(
-            "Server not configured. Run: narrator-ai-cli config init"
-        )
+        raise SystemExit("Server not configured. Run: narrator-ai-cli config init")
     return server.rstrip("/")
 
 
@@ -51,9 +49,7 @@ def get_app_key() -> str:
     cfg = load_config()
     key = os.environ.get("NARRATOR_APP_KEY", cfg.get("app_key", ""))
     if not key:
-        raise SystemExit(
-            "API key not configured. Run: narrator-ai-cli config init"
-        )
+        raise SystemExit("API key not configured. Run: narrator-ai-cli config init")
     return key
 
 

--- a/src/narrator_ai/output.py
+++ b/src/narrator_ai/output.py
@@ -5,7 +5,7 @@ Supports JSON mode (for agents) and rich table mode (for humans).
 
 import json
 import sys
-from typing import Any, Optional
+from typing import Any
 
 from rich.console import Console
 from rich.markup import escape
@@ -21,7 +21,7 @@ def print_json(data: Any):
     print(json.dumps(data, ensure_ascii=False, indent=2, default=str))
 
 
-def print_error(message: str, code: Optional[int] = None):
+def print_error(message: str, code: int | None = None):
     prefix = f"[{code}] " if code else ""
     err_console.print(f"[red]Error: {escape(prefix + message)}[/red]")
 
@@ -34,7 +34,7 @@ def print_info(message: str):
     err_console.print(f"[blue]{message}[/blue]")
 
 
-def print_dict(data: dict, title: Optional[str] = None, json_mode: bool = False):
+def print_dict(data: dict, title: str | None = None, json_mode: bool = False):
     """Print a dict as JSON or a rich panel."""
     if json_mode:
         print_json(data)
@@ -53,7 +53,7 @@ def print_dict(data: dict, title: Optional[str] = None, json_mode: bool = False)
 def print_table(
     items: list[dict],
     columns: list[tuple[str, str]],
-    title: Optional[str] = None,
+    title: str | None = None,
     json_mode: bool = False,
 ):
     """Print a list of dicts as JSON or a rich table.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Shared test fixtures for narrator-ai-cli."""

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -29,8 +29,11 @@ def test_cli_version():
 
 
 def test_cli_no_args_shows_help():
-    """Running with no arguments should show help (no_args_is_help=True)."""
+    """Running with no arguments should show help (no_args_is_help=True).
+
+    Typer/Click returns exit code 2 for no_args_is_help — this is by design,
+    not an error. The important assertion is that help text is displayed.
+    """
     result = runner.invoke(app, [])
-    # Typer returns exit code 0 or 2 for no_args_is_help depending on version
     assert result.exit_code in (0, 2)
-    assert "usage" in result.output.lower() or "narrat" in result.output.lower()
+    assert "narrator" in result.output.lower() or "usage" in result.output.lower()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,36 @@
+"""Smoke tests — verify the package is importable and CLI entry point is callable."""
+
+from typer.testing import CliRunner
+
+from narrator_ai import __version__
+from narrator_ai.cli import app
+
+runner = CliRunner()
+
+
+def test_version_importable():
+    """Package version should be a non-empty string."""
+    assert isinstance(__version__, str)
+    assert len(__version__) > 0
+
+
+def test_cli_help():
+    """CLI --help should exit 0 and show usage info."""
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "narrator-ai-cli" in result.output.lower() or "narrat" in result.output.lower()
+
+
+def test_cli_version():
+    """CLI --version should print version and exit 0."""
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert __version__ in result.output
+
+
+def test_cli_no_args_shows_help():
+    """Running with no arguments should show help (no_args_is_help=True)."""
+    result = runner.invoke(app, [])
+    # Typer returns exit code 0 or 2 for no_args_is_help depending on version
+    assert result.exit_code in (0, 2)
+    assert "usage" in result.output.lower() or "narrat" in result.output.lower()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -29,11 +29,6 @@ def test_cli_version():
 
 
 def test_cli_no_args_shows_help():
-    """Running with no arguments should show help (no_args_is_help=True).
-
-    Typer/Click returns exit code 2 for no_args_is_help — this is by design,
-    not an error. The important assertion is that help text is displayed.
-    """
+    """Running with no arguments should display help text (no_args_is_help=True)."""
     result = runner.invoke(app, [])
-    assert result.exit_code in (0, 2)
     assert "narrator" in result.output.lower() or "usage" in result.output.lower()


### PR DESCRIPTION
## Related Issue

Closes #14

## Summary

- Add `.github/workflows/ci.yml` with 4 CI jobs on Blacksmith runners:
  - **Lint**: `ruff check` + `ruff format --check`
  - **Type Check**: `mypy` with `--ignore-missing-imports`
  - **Test**: `pytest` with coverage across Python 3.10 / 3.11 / 3.12 matrix
  - **Security Scan**: `pip-audit` (dependency vulnerabilities) + `bandit` (SAST)
- Add tool configs in `pyproject.toml` (`[tool.ruff]`, `[tool.mypy]`, `[tool.pytest.ini_options]`, `[tool.bandit]`) aligned with videoDubbing-cli
- Add `[project.optional-dependencies] dev` with ruff, mypy, pytest-cov, bandit, pip-audit
- Create `tests/` with 4 smoke tests: package import, CLI --help, --version, no-args
- Fix existing lint/format/type issues for CI compliance

## Test Plan

- [x] All 4 smoke tests pass locally
- [x] `ruff check .` + `ruff format --check .` pass
- [x] Lint, Type Check, Test (3.10/3.11/3.12) CI jobs pass
- [x] Security Scan runs (fails on 2 real dependency CVEs — tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)