### PR TITLE
fix(ci): upgrade pip before security audit to avoid pip-self CVEs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - run: python -m pip install --upgrade pip
       - run: pip install pip-audit bandit
       - name: Install project
         run: pip install -e ".[dev]"


### PR DESCRIPTION
## Related Issue

Closes #15

## Summary

- Add `python -m pip install --upgrade pip` before pip-audit to avoid CVE-2026-1703 and CVE-2026-3219 in pre-installed pip 25.3

## Test Plan

- [ ] Security Scan CI job passes
- [x] All other CI jobs already passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)