### PR TITLE
feat(ci): add 20% coverage threshold and terminal coverage report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - run: pip install -e ".[dev]" pytest-cov
         env:
           PIP_INDEX_URL: https://pypi.org/simple
-      - run: pytest -v --tb=short --cov=narrator_ai --cov-report=xml
+      - run: pytest -v --tb=short --cov=narrator_ai --cov-report=term --cov-report=xml --cov-fail-under=20
 
   security:
     name: Security Scan


### PR DESCRIPTION
## Related Issue

Closes #17

## Summary

- Add `--cov-fail-under=20` (baseline is 30%, threshold set with buffer)
- Add `--cov-report=term` for visible coverage table in CI logs

## Test Plan

- [x] Coverage locally is 30% (above 20% threshold)
- [ ] CI passes with new threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)