### PR TITLE
fix(ci): SHA-pin actions/checkout + actions/setup-python (closes #19)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
     name: Lint
     runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install ruff
@@ -26,8 +26,8 @@ jobs:
     name: Type Check
     runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: pip install -e ".[dev]" mypy types-PyYAML
@@ -42,8 +42,8 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install -e ".[dev]" pytest-cov
@@ -55,8 +55,8 @@ jobs:
     name: Security Scan
     runs-on: ${{ vars.RUNNER_LABEL || 'blacksmith-2vcpu-ubuntu-2404' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
       - run: python -m pip install --upgrade pip


### PR DESCRIPTION
## Summary

Pin `actions/checkout@v4` (4×) and `actions/setup-python@v5` (4×) to commit SHAs across `.github/workflows/ci.yml`. Zero behavioural change — same commits the floating tags currently point to.

## Why

Tags are mutable. Pinning to SHA is the enterprise standard per [Gridltd-DevOps/.github#193](https://github.com/Gridltd-DevOps/.github/issues/193). The SHA Pin Enforce ruleset will block any future PR touching this file otherwise.

## Test Plan

- [x] YAML still parses cleanly
- [x] Same SHAs the floating tags currently resolve to — zero behavioural delta
- [ ] CI passes on this branch

## Related Issue

Closes #19. Parent: Gridltd-DevOps/.github#193 (cross-org SHA-pin audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)