### PR TITLE
chore: add pre-commit hooks (gitleaks + linting)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.8
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+


### PR DESCRIPTION
## Related Issue

Closes #21

## Summary

- Add `.pre-commit-config.yaml` with gitleaks secret scanning
- Add ruff check + ruff format hooks for Python

## Test Plan

- [x] Config matches org standard (videoDubbing-cli reference)
- [ ] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)