### PR TITLE
feat(test): add unit tests for config, output, and dubbing modules

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,82 @@
+"""Tests for narrator_ai.config module."""
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from narrator_ai.config import (
+    DEFAULT_CONFIG,
+    get_app_key,
+    get_server,
+    get_timeout,
+    load_config,
+    save_config,
+)
+
+
+def test_default_config_values():
+    assert DEFAULT_CONFIG["server"] == "https://openapi.jieshuo.cn"
+    assert DEFAULT_CONFIG["app_key"] == ""
+    assert DEFAULT_CONFIG["timeout"] == 30
+
+
+def test_load_config_returns_defaults_when_no_file(tmp_path):
+    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"):
+        cfg = load_config()
+    assert cfg["server"] == DEFAULT_CONFIG["server"]
+    assert cfg["timeout"] == DEFAULT_CONFIG["timeout"]
+
+
+def test_save_and_load_config(tmp_path):
+    config_file = tmp_path / "config.yaml"
+    config_dir = tmp_path
+    with patch("narrator_ai.config.CONFIG_FILE", config_file), \
+         patch("narrator_ai.config.CONFIG_DIR", config_dir):
+        save_config({"server": "https://test.example.com", "app_key": "test-key"})
+        cfg = load_config()
+    assert cfg["server"] == "https://test.example.com"
+    assert cfg["app_key"] == "test-key"
+    assert cfg["timeout"] == 30  # default preserved
+
+
+def test_get_server_from_env():
+    with patch.dict(os.environ, {"NARRATOR_SERVER": "https://env.example.com"}):
+        assert get_server() == "https://env.example.com"
+
+
+def test_get_server_strips_trailing_slash():
+    with patch.dict(os.environ, {"NARRATOR_SERVER": "https://example.com/"}):
+        assert get_server() == "https://example.com"
+
+
+def test_get_server_raises_when_not_configured(tmp_path):
+    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"), \
+         patch.dict(os.environ, {}, clear=True):
+        # DEFAULT_CONFIG has server set, so this won't raise
+        server = get_server()
+        assert server == DEFAULT_CONFIG["server"].rstrip("/")
+
+
+def test_get_app_key_from_env():
+    with patch.dict(os.environ, {"NARRATOR_APP_KEY": "env-key-123"}):
+        assert get_app_key() == "env-key-123"
+
+
+def test_get_app_key_raises_when_not_configured(tmp_path):
+    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"), \
+         patch.dict(os.environ, {}, clear=True):
+        with pytest.raises(SystemExit):
+            get_app_key()
+
+
+def test_get_timeout_from_env():
+    with patch.dict(os.environ, {"NARRATOR_TIMEOUT": "60"}):
+        assert get_timeout() == 60
+
+
+def test_get_timeout_default():
+    with patch.dict(os.environ, {}, clear=True), \
+         patch("narrator_ai.config.CONFIG_FILE", Path("/nonexistent")):
+        assert get_timeout() == 30

--- a/tests/test_dubbing.py
+++ b/tests/test_dubbing.py
@@ -1,0 +1,62 @@
+"""Tests for narrator_ai.commands.dubbing — voice list filtering logic."""
+
+from typer.testing import CliRunner
+
+from narrator_ai.commands.dubbing import DUBBING_LIST, app
+
+runner = CliRunner()
+
+
+def test_dubbing_list_not_empty():
+    assert len(DUBBING_LIST) > 0
+
+
+def test_dubbing_list_has_required_fields():
+    for voice in DUBBING_LIST:
+        assert "name" in voice
+        assert "id" in voice
+        assert "type" in voice
+        assert "tag" in voice
+
+
+def test_dubbing_list_json_output():
+    result = runner.invoke(app, ["list", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) > 0
+
+
+def test_dubbing_list_filter_by_lang():
+    result = runner.invoke(app, ["list", "--lang", "英语", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert all(v["type"] == "英语" for v in data)
+
+
+def test_dubbing_list_filter_by_tag():
+    result = runner.invoke(app, ["list", "--tag", "通用男声", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert all(v["tag"] == "通用男声" for v in data)
+
+
+def test_dubbing_languages_json():
+    result = runner.invoke(app, ["languages", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert any(item["language"] == "普通话" for item in data)
+
+
+def test_dubbing_tags_json():
+    result = runner.invoke(app, ["tags", "--json"])
+    assert result.exit_code == 0
+    import json
+    data = json.loads(result.output)
+    assert isinstance(data, list)
+    assert len(data) > 0

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,51 @@
+"""Tests for narrator_ai.output module."""
+
+import json
+from io import StringIO
+from unittest.mock import patch
+
+from narrator_ai.output import print_json, print_error, print_success, print_info
+
+
+def test_print_json_dict(capsys):
+    print_json({"key": "value", "num": 42})
+    out = json.loads(capsys.readouterr().out)
+    assert out["key"] == "value"
+    assert out["num"] == 42
+
+
+def test_print_json_list(capsys):
+    print_json([1, 2, 3])
+    out = json.loads(capsys.readouterr().out)
+    assert out == [1, 2, 3]
+
+
+def test_print_json_unicode(capsys):
+    print_json({"name": "测试"})
+    out = json.loads(capsys.readouterr().out)
+    assert out["name"] == "测试"
+
+
+def test_print_error_with_code(capsys):
+    print_error("something failed", code=404)
+    err = capsys.readouterr().err
+    assert "404" in err
+    assert "something failed" in err
+
+
+def test_print_error_without_code(capsys):
+    print_error("generic error")
+    err = capsys.readouterr().err
+    assert "generic error" in err
+
+
+def test_print_success(capsys):
+    print_success("done!")
+    err = capsys.readouterr().err
+    assert "done!" in err
+
+
+def test_print_info(capsys):
+    print_info("processing...")
+    err = capsys.readouterr().err
+    assert "processing..." in err


### PR DESCRIPTION
## Related Issue

Closes #23

## Summary

- `test_config.py`: 10 tests — config load/save, env vars, defaults, error paths
- `test_output.py`: 7 tests — JSON output, error/success/info formatting
- `test_dubbing.py`: 7 tests — voice list, filtering by lang/tag, JSON output
- Coverage: 30% → 37% (28 tests total, all pass)

## Test Plan

- [x] All 28 tests pass locally
- [x] Coverage above 20% threshold (37%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)