### PR TITLE
fix: resolve ruff lint errors in new test files

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,8 +32,7 @@ def test_load_config_returns_defaults_when_no_file(tmp_path):
 def test_save_and_load_config(tmp_path):
     config_file = tmp_path / "config.yaml"
     config_dir = tmp_path
-    with patch("narrator_ai.config.CONFIG_FILE", config_file), \
-         patch("narrator_ai.config.CONFIG_DIR", config_dir):
+    with patch("narrator_ai.config.CONFIG_FILE", config_file), patch("narrator_ai.config.CONFIG_DIR", config_dir):
         save_config({"server": "https://test.example.com", "app_key": "test-key"})
         cfg = load_config()
     assert cfg["server"] == "https://test.example.com"
@@ -52,8 +51,7 @@ def test_get_server_strips_trailing_slash():
 
 
 def test_get_server_raises_when_not_configured(tmp_path):
-    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"), \
-         patch.dict(os.environ, {}, clear=True):
+    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"), patch.dict(os.environ, {}, clear=True):
         # DEFAULT_CONFIG has server set, so this won't raise
         server = get_server()
         assert server == DEFAULT_CONFIG["server"].rstrip("/")
@@ -65,10 +63,12 @@ def test_get_app_key_from_env():
 
 
 def test_get_app_key_raises_when_not_configured(tmp_path):
-    with patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"), \
-         patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(SystemExit):
-            get_app_key()
+    with (
+        patch("narrator_ai.config.CONFIG_FILE", tmp_path / "nonexistent.yaml"),
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(SystemExit),
+    ):
+        get_app_key()
 
 
 def test_get_timeout_from_env():
@@ -77,6 +77,5 @@ def test_get_timeout_from_env():
 
 
 def test_get_timeout_default():
-    with patch.dict(os.environ, {}, clear=True), \
-         patch("narrator_ai.config.CONFIG_FILE", Path("/nonexistent")):
+    with patch.dict(os.environ, {}, clear=True), patch("narrator_ai.config.CONFIG_FILE", Path("/nonexistent")):
         assert get_timeout() == 30

--- a/tests/test_dubbing.py
+++ b/tests/test_dubbing.py
@@ -1,5 +1,7 @@
 """Tests for narrator_ai.commands.dubbing — voice list filtering logic."""
 
+import json
+
 from typer.testing import CliRunner
 
 from narrator_ai.commands.dubbing import DUBBING_LIST, app
@@ -22,7 +24,6 @@ def test_dubbing_list_has_required_fields():
 def test_dubbing_list_json_output():
     result = runner.invoke(app, ["list", "--json"])
     assert result.exit_code == 0
-    import json
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) > 0
@@ -31,7 +32,6 @@ def test_dubbing_list_json_output():
 def test_dubbing_list_filter_by_lang():
     result = runner.invoke(app, ["list", "--lang", "英语", "--json"])
     assert result.exit_code == 0
-    import json
     data = json.loads(result.output)
     assert all(v["type"] == "英语" for v in data)
 
@@ -39,7 +39,6 @@ def test_dubbing_list_filter_by_lang():
 def test_dubbing_list_filter_by_tag():
     result = runner.invoke(app, ["list", "--tag", "通用男声", "--json"])
     assert result.exit_code == 0
-    import json
     data = json.loads(result.output)
     assert all(v["tag"] == "通用男声" for v in data)
 
@@ -47,7 +46,6 @@ def test_dubbing_list_filter_by_tag():
 def test_dubbing_languages_json():
     result = runner.invoke(app, ["languages", "--json"])
     assert result.exit_code == 0
-    import json
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert any(item["language"] == "普通话" for item in data)
@@ -56,7 +54,6 @@ def test_dubbing_languages_json():
 def test_dubbing_tags_json():
     result = runner.invoke(app, ["tags", "--json"])
     assert result.exit_code == 0
-    import json
     data = json.loads(result.output)
     assert isinstance(data, list)
     assert len(data) > 0

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,10 +1,8 @@
 """Tests for narrator_ai.output module."""
 
 import json
-from io import StringIO
-from unittest.mock import patch
 
-from narrator_ai.output import print_json, print_error, print_success, print_info
+from narrator_ai.output import print_error, print_info, print_json, print_success
 
 
 def test_print_json_dict(capsys):


### PR DESCRIPTION
## Summary

- Fix lint errors introduced by #24 (new test files)
- Remove unused imports, fix import sorting, combine with statements

## Test Plan

- [x] ruff check . passes
- [x] ruff format --check . passes
- [x] 28 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)