### PR TITLE
chore(security): add Dependabot for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps):"
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci(deps):"


### PR DESCRIPTION
## Related Issue
Closes #26
## Summary
- Add dependabot.yml with pip and GitHub Actions ecosystems
- Weekly scan on Monday, max 5 open PRs per ecosystem
## Test Plan
- [ ] Dependabot starts creating PRs after merge